### PR TITLE
Changed networks

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -361,14 +361,14 @@ resource "aws_key_pair" "dev_access" {
 resource "aws_instance" "dev_mdb_access" {
   ami                         = "ami-0b898040803850657"  # amazon linux 2
   instance_type               = "t2.micro"
-  subnet_id                   = "${module.ecs_vpc.private_subnet_ids[0]}"
+  subnet_id                   = "${module.ecs_vpc.public_subnet_ids[0]}"
   associate_public_ip_address = true
   vpc_security_group_ids      = [ "${aws_security_group.office_access.id}" ]
   key_name                    = "${aws_key_pair.dev_access.key_name}"
 
   tags = "${merge(local.common_tags,
             map(
-                "Name", "dev-access-${var.service}"
+                "Name", "${var.service}-dev-access"
             )
           )}"
 }


### PR DESCRIPTION
Changed the subnet_id for the dev access node to public so that we can remote into it from HSV. I also changed the name to be easier to see from the UI.