### PR TITLE
Add New Relic environment variables/secrets

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,6 +22,13 @@ data "aws_acm_certificate" "certificate" {
   statuses = ["ISSUED"]
 }
 
+# Secrets Manager Secret - New Relic License Key
+resource "aws_secretsmanager_secret" "new_relic_license_key" {
+  name        = "avrae/${var.env}/new-relic-license-key"
+  description = "License key for New Relic."
+  tags        = "${local.common_tags}"
+}
+
 # Secrets Manager Secret - Avrae Bot Sentry DSN
 resource "aws_secretsmanager_secret" "avrae_bot_sentry_dsn" {
   name        = "avrae/${var.env}/avrae-bot-sentry-dsn"
@@ -214,11 +221,14 @@ module "taine_ecs" {
                             "${module.dynamodb_taine.dynamodb_iam_policy_arn}"
                           ]
   environment_variables = [
-                            {"name" = "DYNAMODB_URL", value = "https://dynamodb.us-east-1.amazonaws.com"}
+                            {"name" = "DYNAMODB_URL", value = "https://dynamodb.us-east-1.amazonaws.com"},
+                            {"name" = "NEW_RELIC_CONFIG_FILE", value = "newrelic.ini"},
+                            {"name" = "NEW_RELIC_ENVIRONMENT", value = "production"},
                           ]
   secrets               = [
                             {"name" = "DISCORD_TOKEN", "valueFrom" = "${aws_secretsmanager_secret.taine_discord_token.arn}"},
                             {"name" = "GITHUB_TOKEN", "valueFrom" = "${aws_secretsmanager_secret.taine_github_token.arn}"},
+                            {"name" = "NEW_RELIC_LICENSE_KEY", "valueFrom" = "${aws_secretsmanager_secret.new_relic_license_key.arn}"},
                             {"name" = "SENTRY_DSN", "valueFrom" = "${aws_secretsmanager_secret.taine_sentry_dsn.arn}"}
                           ]
 }
@@ -250,10 +260,13 @@ module "avrae_service_ecs" {
                             "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
                           ]
   environment_variables = [
-                            {"name" = "REDIS_URL", value = "redis://${module.redis_avrae.hostname}"}
+                            {"name" = "NEW_RELIC_CONFIG_FILE", value = "newrelic.ini"},
+                            {"name" = "NEW_RELIC_ENVIRONMENT", value = "production"},
+                            {"name" = "REDIS_URL", value = "redis://${module.redis_avrae.hostname}"},
                           ]
   secrets               = [
                             {"name" = "MONGO_URL", valueFrom = "${aws_secretsmanager_secret.mongo_url.arn}"},
+                            {"name" = "NEW_RELIC_LICENSE_KEY", "valueFrom" = "${aws_secretsmanager_secret.new_relic_license_key.arn}"},
                             {"name" = "SENTRY_DSN", "valueFrom" = "${aws_secretsmanager_secret.avrae_service_sentry_dsn.arn}"}
                           ]
 }
@@ -284,6 +297,8 @@ module "avrae_bot_ecs" {
                             {"name" = "REDIS_URL", value = "redis://${module.redis_avrae.hostname}"},
                             {"name" = "DISCORD_OWNER_USER_ID", value = "${var.discord_owner_id}"},
                             {"name" = "DICECLOUD_USER", value = "${var.dicecloud_username}"},
+                            {"name" = "NEW_RELIC_CONFIG_FILE", value = "newrelic.ini"},
+                            {"name" = "NEW_RELIC_ENVIRONMENT", value = "production"},
                           ]
   secrets               = [
                             {"name" = "MONGO_URL", valueFrom = "${aws_secretsmanager_secret.mongo_url.arn}"},
@@ -293,6 +308,7 @@ module "avrae_bot_ecs" {
                             {"name" = "DICECLOUD_TOKEN", "valueFrom" = "${aws_secretsmanager_secret.avrae_bot_dicecloud_token.arn}"},
                             {"name" = "DBL_TOKEN", "valueFrom" = "${aws_secretsmanager_secret.avrae_bot_dbl_token.arn}"},
                             {"name" = "GOOGLE_SERVICE_ACCOUNT", "valueFrom" = "${aws_secretsmanager_secret.avrae_bot_google_service.arn}"},
+                            {"name" = "NEW_RELIC_LICENSE_KEY", "valueFrom" = "${aws_secretsmanager_secret.new_relic_license_key.arn}"},
                           ]
 
   # restart container instantly on deploy

--- a/main.tf
+++ b/main.tf
@@ -297,8 +297,8 @@ module "avrae_bot_ecs" {
                             {"name" = "REDIS_URL", value = "redis://${module.redis_avrae.hostname}"},
                             {"name" = "DISCORD_OWNER_USER_ID", value = "${var.discord_owner_id}"},
                             {"name" = "DICECLOUD_USER", value = "${var.dicecloud_username}"},
-                            {"name" = "NEW_RELIC_CONFIG_FILE", value = "newrelic.ini"},
-                            {"name" = "NEW_RELIC_ENVIRONMENT", value = "production"},
+                            #{"name" = "NEW_RELIC_CONFIG_FILE", value = "newrelic.ini"},
+                            #{"name" = "NEW_RELIC_ENVIRONMENT", value = "production"},
                           ]
   secrets               = [
                             {"name" = "MONGO_URL", valueFrom = "${aws_secretsmanager_secret.mongo_url.arn}"},
@@ -308,7 +308,7 @@ module "avrae_bot_ecs" {
                             {"name" = "DICECLOUD_TOKEN", "valueFrom" = "${aws_secretsmanager_secret.avrae_bot_dicecloud_token.arn}"},
                             {"name" = "DBL_TOKEN", "valueFrom" = "${aws_secretsmanager_secret.avrae_bot_dbl_token.arn}"},
                             {"name" = "GOOGLE_SERVICE_ACCOUNT", "valueFrom" = "${aws_secretsmanager_secret.avrae_bot_google_service.arn}"},
-                            {"name" = "NEW_RELIC_LICENSE_KEY", "valueFrom" = "${aws_secretsmanager_secret.new_relic_license_key.arn}"},
+                            #{"name" = "NEW_RELIC_LICENSE_KEY", "valueFrom" = "${aws_secretsmanager_secret.new_relic_license_key.arn}"},
                           ]
 
   # restart container instantly on deploy


### PR DESCRIPTION
Does the things for New Relic. Yes, setting the config file explicitly to the default "newrelic.ini" is required because New Relic is... weird.