### PR TITLE
Add env vars, ECS policy for bot clustering

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -361,6 +361,10 @@ module "avrae_bot_ecs" {
       name = "NEW_RELIC_ENVIRONMENT"
       value  = "production"
     },
+    {
+      name = "NUM_CLUSTERS"
+      value  = "1"
+    },
   ]
   secrets = [
     {
@@ -400,7 +404,7 @@ module "avrae_bot_ecs" {
   # restart container instantly on deploy
   deployment_minimum_healthy_percent = 0
   deployment_maximum_percent         = 100
-  instance_count                     = 1
+  instance_count                     = 1  # MUST EQUAL NUM_CLUSTERS ENV VAR!
   max_instance_count                 = 1
 
   # 2 vCPUs, 12GB RAM
@@ -467,6 +471,14 @@ module "avrae_bot_nightly_ecs" {
       name = "DEFAULT_PREFIX"
       value  = "$"
     },
+    {
+      name = "NUM_CLUSTERS"
+      value  = "1"
+    },
+    {
+      name = "NUM_SHARDS"  # explicitly set num shards for clustering test
+      value  = "2"
+    },
   ]
   secrets = [
     {
@@ -502,7 +514,7 @@ module "avrae_bot_nightly_ecs" {
   # restart container instantly on deploy
   deployment_minimum_healthy_percent = 0
   deployment_maximum_percent         = 100
-  instance_count                     = 1
+  instance_count                     = 1  # MUST EQUAL NUM_CLUSTERS ENV VAR!
   max_instance_count                 = 1
 
   # 1 vCPU, 4GB RAM

--- a/modules/ecs-fargate/main.tf
+++ b/modules/ecs-fargate/main.tf
@@ -71,6 +71,35 @@ resource "aws_iam_role_policy_attachment" "role_policy_attach" {
   policy_arn = element(var.ecs_role_policy_arns, count.index)
 }
 
+resource "aws_iam_policy" "list_tasks_policy" {
+  name        = "${var.service}-${var.env}-task-policy"
+  path        = "/"
+  description = "Used to give access to ECS task metadata to running tasks"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+   {
+     "Effect": "Allow",
+     "Action": [
+       "ecs:ListTasks"
+     ],
+     "Resource": [
+       "*"
+     ]
+   }
+  ]
+}
+EOF
+
+}
+
+resource "aws_iam_role_policy_attachment" "service_deploy_policy_attach" {
+  policy_arn = aws_iam_policy.list_tasks_policy.arn
+  role = aws_iam_role.ecs_service_role.name
+}
+
 resource "aws_ecs_task_definition" "service_task_definition" {
   family = "${var.service}-ecs-task-definition"
   network_mode = "awsvpc"

--- a/modules/ecs-fargate/main.tf
+++ b/modules/ecs-fargate/main.tf
@@ -95,7 +95,7 @@ EOF
 
 }
 
-resource "aws_iam_role_policy_attachment" "service_deploy_policy_attach" {
+resource "aws_iam_role_policy_attachment" "role_policy_attach2" {
   policy_arn = aws_iam_policy.list_tasks_policy.arn
   role = aws_iam_role.ecs_service_role.name
 }


### PR DESCRIPTION
Sets up the required env vars for clustering, and gives the ECS task permissions to list tasks (so it can check which tasks are dead if necessary).

**Note that merging this will trigger a bot restart.**