### PR TITLE
add PutObjectAcl permissions to deploy user

### DIFF
--- a/modules/iam-deploy/main.tf
+++ b/modules/iam-deploy/main.tf
@@ -49,18 +49,11 @@ resource "aws_iam_policy" "service_deploy_policy" {
     {
         "Effect": "Allow",
         "Action": [
+            "s3:ListBucket",
             "s3:PutObject",
-            "s3:DeleteObject",
-            "s3:PutObjectTagging"
-        ],
-        "Resource": [
-            "arn:aws:s3:::media.avrae.io*"
-        ]
-    },
-    {
-        "Effect": "Allow",
-        "Action": [
-            "s3:ListBucket"
+            "s3:PutObjectTagging",
+            "s3:PutObjectAcl",
+            "s3:DeleteObject"
         ],
         "Resource": [
             "arn:aws:s3:::media.avrae.io*"


### PR DESCRIPTION
Currently, the deploy user is missing the s3:PutObjectAcl (needed to make the uploaded file public) permissions, which I think is what's causing 403s when travis tries to upload the help file to S3.