### PR TITLE
add secrets for avrae service JWT/oauth

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -77,6 +77,13 @@ resource "aws_secretsmanager_secret" "avrae_bot_discord_token" {
   tags        = local.common_tags
 }
 
+# Secrets Manager Secret - Avrae Discord Client Secret
+resource "aws_secretsmanager_secret" "avrae_discord_client_secret" {
+  name        = "avrae/${var.env}/avrae-discord-client-secret"
+  description = "Discord client secret for the Avrae application."
+  tags        = local.common_tags
+}
+
 # Secrets Manager Secret - Avrae Dicecloud Password
 resource "aws_secretsmanager_secret" "avrae_bot_dicecloud_pass" {
   name        = "avrae/${var.env}/avrae-bot-dicecloud-pass"
@@ -109,6 +116,13 @@ resource "aws_secretsmanager_secret" "avrae_bot_google_service" {
 resource "aws_secretsmanager_secret" "avrae_bot_nightly_discord_token" {
   name        = "avrae/${var.env}/avrae-bot-nightly-discord-token"
   description = "Discord token for the Avrae Bot."
+  tags        = local.common_tags
+}
+
+# Secrets Manager Secret - Avrae Service JWT Secret
+resource "aws_secretsmanager_secret" "avrae_service_jwt_secret" {
+  name        = "avrae/${var.env}/avrae-service-jwt-secret"
+  description = "JWT secret for tokens issues to avrae.io from the avrae service."
   tags        = local.common_tags
 }
 
@@ -321,6 +335,10 @@ module "avrae_service_ecs" {
       name = "REDIS_URL"
       value  = "redis://${module.redis_avrae.hostname}"
     },
+    {
+      name = "DISCORD_CLIENT_ID"
+      value  = var.discord_client_id
+    },
   ]
   secrets = [
     {
@@ -334,6 +352,14 @@ module "avrae_service_ecs" {
     {
       name      = "SENTRY_DSN"
       valueFrom = aws_secretsmanager_secret.avrae_service_sentry_dsn.arn
+    },
+    {
+      name      = "DISCORD_CLIENT_SECRET"
+      valueFrom = aws_secretsmanager_secret.avrae_discord_client_secret.arn
+    },
+    {
+      name      = "JWT_SECRET"
+      valueFrom = aws_secretsmanager_secret.avrae_service_jwt_secret.arn
     },
   ]
 }

--- a/main.tf
+++ b/main.tf
@@ -873,3 +873,4 @@ module "character_computation_api" {
   vpc_id        = module.ecs_vpc.aws_vpc_main_id
   whitelist_sgs = [module.avrae_bot_ecs.security_group_id, module.avrae_bot_nightly_ecs.security_group_id]
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -34,6 +34,10 @@ variable "discord_owner_id" {
   description = "Discord User ID of the owner of the Avrae bot"
 }
 
+variable "discord_client_id" {
+  description = "Discord Client ID of the Avrae application"
+}
+
 variable "dicecloud_username" {
   description = "Dicecloud username of the Avrae bot"
 }


### PR DESCRIPTION
Necessary from moving from an OAuth2 implicit grant to an auth code grant on avrae.io. Adds the following secrets:

- `avrae/live/avrae-discord-client-secret` - the Discord OAuth2 client secret of the Avrae application
- `avrae/live/avrae-service-jwt-secret` - a secret used for JWTs issued to avrae.io users by the avrae service

and the following TF var:

- `discord_client_id` - the Discord OAuth2 client id of the Avrae application