### PR TITLE
add discord bot token to avrae service env vars

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -361,6 +361,10 @@ module "avrae_service_ecs" {
       name      = "JWT_SECRET"
       valueFrom = aws_secretsmanager_secret.avrae_service_jwt_secret.arn
     },
+    {
+      name      = "DISCORD_BOT_TOKEN"
+      valueFrom = aws_secretsmanager_secret.avrae_bot_discord_token.arn
+    },
   ]
 }
 


### PR DESCRIPTION
Used in avrae service to make requests on behalf of the bot (e.g. "what are the role IDs in server X")