### PR TITLE
create es domain for avrae

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -339,6 +339,10 @@ module "avrae_service_ecs" {
       name = "DISCORD_CLIENT_ID"
       value  = var.discord_client_id
     },
+    {
+      name = "ELASTICSEARCH_ENDPOINT"
+      value  = module.alias_workshop_elasticsearch.es_endpoint
+    },
   ]
   secrets = [
     {
@@ -880,3 +884,11 @@ module "character_computation_api" {
   whitelist_sgs = [module.avrae_bot_ecs.security_group_id, module.avrae_bot_nightly_ecs.security_group_id]
 }
 
+module "alias_workshop_elasticsearch" {
+  source = "./modules/es-alias-workshop"
+  env               = var.env
+  service           = var.service
+  subnet_ids        = module.ecs_vpc.private_subnet_ids
+  vpc_id            = module.ecs_vpc.aws_vpc_main_id
+  es_whitelist_sgs  = [module.avrae_bot_ecs.security_group_id, module.avrae_bot_nightly_ecs.security_group_id, module.avrae_service_ecs.security_group_id]
+}

--- a/modules/es-alias-workshop/main.tf
+++ b/modules/es-alias-workshop/main.tf
@@ -1,0 +1,62 @@
+# ==== ElasticSearch: Avrae Alias Workshop ====
+
+# ---- security groups ----
+resource "aws_security_group" "es" {
+  name = "${var.service}-${var.env}-workshop-elasticsearch-access"
+  description = "Managed by Terraform"
+  vpc_id = var.vpc_id
+
+  ingress {
+    from_port = 443
+    to_port = 443
+    protocol = "tcp"
+    security_groups = var.es_whitelist_sgs
+  }
+}
+
+resource "aws_iam_service_linked_role" "es" {
+  aws_service_name = "es.amazonaws.com"
+}
+
+# ---- elasticsearch domain ----
+resource "aws_elasticsearch_domain" "workshop_es" {
+  domain_name = "${var.service}-${var.env}-workshop-collections"
+
+  elasticsearch_version = "7.7"
+
+  cluster_config {
+    instance_type = "r5.large.elasticsearch"
+  }
+
+  vpc_options {
+    subnet_ids = var.subnet_ids
+    security_group_ids = [aws_security_group.es.id]
+  }
+
+  access_policies = <<CONFIG
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": "es:*",
+            "Principal": "*",
+            "Effect": "Allow",
+            "Resource": "arn:aws:es:*:*:domain/${aws_elasticsearch_domain.workshop_es.domain_name}/*"
+        }
+    ]
+}
+CONFIG
+
+  ebs_options {
+    ebs_enabled = true
+    volume_size = 10
+  }
+
+  tags = {
+    Component = var.service
+    Environment = var.env
+  }
+
+  depends_on = [aws_iam_service_linked_role.es]
+}
+

--- a/modules/es-alias-workshop/main.tf
+++ b/modules/es-alias-workshop/main.tf
@@ -41,7 +41,7 @@ resource "aws_elasticsearch_domain" "workshop_es" {
             "Action": "es:*",
             "Principal": "*",
             "Effect": "Allow",
-            "Resource": "arn:aws:es:*:*:domain/${aws_elasticsearch_domain.workshop_es.domain_name}/*"
+            "Resource": "arn:aws:es:*:*:domain/${var.service}-${var.env}-workshop-collections/*"
         }
     ]
 }

--- a/modules/es-alias-workshop/outputs.tf
+++ b/modules/es-alias-workshop/outputs.tf
@@ -1,0 +1,3 @@
+output "es_endpoint" {
+  value = aws_elasticsearch_domain.workshop_es.endpoint
+}

--- a/modules/es-alias-workshop/variables.tf
+++ b/modules/es-alias-workshop/variables.tf
@@ -1,0 +1,23 @@
+variable "service" {
+  description = "Service name of the account"
+}
+
+variable "env" {
+  description = "Environment name"
+}
+
+variable "vpc_id" {
+  description = "Default VPC from DDB"
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "List of subnet ids"
+}
+
+variable "es_whitelist_sgs" {
+  type        = list(string)
+  description = "List of security groups to whitelist ElasticSearch access from."
+  default     = []
+}
+


### PR DESCRIPTION
Creates an ElasticSearch domain for Avrae for use in the alias workshop (text searching collections by  names/titles/popularity).

Access to the ES endpoints is restricted to the Avrae VPC using security groups.