### PR TITLE
add S3 module to avrae

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -880,3 +880,12 @@ module "character_computation_api" {
   whitelist_sgs = [module.avrae_bot_ecs.security_group_id, module.avrae_bot_nightly_ecs.security_group_id]
 }
 
+module "s3_avrae" {
+  source        = "./modules/s3-avrae"
+  env           = var.env
+  service       = var.service
+  region        = var.region
+  vpc_id        = module.ecs_vpc.aws_vpc_main_id
+  s3_prefix     = var.s3_prefix
+  whitelist_sgs = [module.avrae_bot_ecs.security_group_id, module.avrae_bot_nightly_ecs.security_group_id]
+}

--- a/modules/s3-avrae/main.tf
+++ b/modules/s3-avrae/main.tf
@@ -1,0 +1,74 @@
+locals {
+  common_tags = {
+    Component = var.service
+    Environment = var.env
+  }
+}
+
+# ==== S3 Buckets ====
+# monster token bucket
+resource "aws_s3_bucket" "monster_tokens" {
+  bucket = "${var.s3_prefix}-${var.region}-${var.service}-${var.env}-monster-tokens"
+  acl = "private"
+  # https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies-vpc-endpoint.html#example-bucket-policies-restrict-access-vpc
+  # allows access from the avrae vpc
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "avrae-vpc-access",
+      "Principal": "*",
+      "Action": "s3:GetObject",
+      "Effect": "Allow",
+      "Resource": ["arn:aws:s3:::${aws_s3_bucket.monster_tokens.arn}",
+                   "arn:aws:s3:::${aws_s3_bucket.monster_tokens.arn}/*"],
+      "Condition": {
+        "StringEquals": {
+          "aws:SourceVpc": "${var.vpc_id}"
+        }
+      }
+    }
+  ]
+}
+POLICY
+
+  tags = merge(
+  local.common_tags,
+  {
+    "Name" = "${var.service}-monster-tokens"
+  },
+  )
+}
+
+# ==== VPC ====
+# Security Group: S3 Endpoint
+resource "aws_security_group" "tokens_s3" {
+  name = "${var.service}-${var.env}-s3-access"
+  description = "Security group attached to Avrae S3 gateway endpoint"
+  vpc_id = var.vpc_id
+  tags = {
+    Name = "${var.service}-${var.env} S3 Gateway Endpoint Access"
+    env = var.env
+  }
+
+  ingress {
+    from_port = 443
+    to_port = 443
+    protocol = "tcp"
+    security_groups = var.whitelist_sgs
+  }
+}
+
+# VPC: S3 interface endpoint
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id = var.vpc_id
+  service_name = "com.amazonaws.${var.region}.s3"
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids = [
+    aws_security_group.tokens_s3.id,
+  ]
+
+  private_dns_enabled = true
+}

--- a/modules/s3-avrae/outputs.tf
+++ b/modules/s3-avrae/outputs.tf
@@ -1,0 +1,3 @@
+output "token_s3_endpoint" {
+  value = aws_s3_bucket.monster_tokens.bucket_domain_name
+}

--- a/modules/s3-avrae/variables.tf
+++ b/modules/s3-avrae/variables.tf
@@ -1,0 +1,25 @@
+variable "service" {
+  description = "Service name of the account"
+}
+
+variable "env" {
+  description = "Environment name"
+}
+
+variable "region" {
+  description = "AWS region"
+}
+
+variable "vpc_id" {
+  description = "ID of the VPC to allow S3 access from"
+}
+
+variable "s3_prefix" {
+  description = "S3 bucket prefix"
+}
+
+variable "whitelist_sgs" {
+  type        = list(string)
+  description = "List of security groups to whitelist S3 access from."
+  default     = []
+}


### PR DESCRIPTION
This PR adds the S3 bucket for the monster tokens project, and sets up a standardized S3 framework for buckets in the future.

By creating a VPC interface endpoint, we control the access to the objects in the buckets to only services in the whitelisted security groups.