### PR TITLE
add infra for automatic lambda deploys

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -187,6 +187,7 @@ module "iam_deploy" {
   service    = var.service
   region     = var.region
   account_id = var.account_id
+  s3_prefix  = var.s3_prefix
 }
 
 # DynamoDB

--- a/modules/iam-deploy/main.tf
+++ b/modules/iam-deploy/main.tf
@@ -58,6 +58,16 @@ resource "aws_iam_policy" "service_deploy_policy" {
       ],
       "Resource": [
         "arn:aws:s3:::media.avrae.io*",
+        "arn:aws:s3:::${var.s3_prefix}-${var.region}-${var.service}-${var.env}*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "lambda:UpdateFunctionCode"
+      ],
+      "Resource": [
+        "arn:aws:lambda:${var.region}:${var.account_id}:function:${var.service}-${var.env}*"
       ]
     }
   ]

--- a/modules/iam-deploy/main.tf
+++ b/modules/iam-deploy/main.tf
@@ -16,54 +16,53 @@ resource "aws_iam_policy" "service_deploy_policy" {
 {
   "Version": "2012-10-17",
   "Statement": [
-   {
-     "Effect": "Allow",
-     "Action": [
-       "ecr:*"
-     ],
-     "Resource": [
-       "arn:aws:ecr:${var.region}:${var.account_id}:repository/avrae/taine",
-       "arn:aws:ecr:${var.region}:${var.account_id}:repository/avrae/avrae-bot",
-       "arn:aws:ecr:${var.region}:${var.account_id}:repository/avrae/avrae-service",
-       "arn:aws:ecr:${var.region}:${var.account_id}:repository/avrae/avrae-io"
-     ]
-   },
-   {
-     "Effect": "Allow",
-     "Action": [
-       "ecr:GetAuthorizationToken"
-     ],
-     "Resource": [
-       "*"
-     ]
-   },
-   {
-     "Effect": "Allow",
-     "Action": [
-       "ecs:DescribeServices",
-       "ecs:Update*"
-     ],
-     "Resource": [
-       "*"
-     ]
-   },
     {
-        "Effect": "Allow",
-        "Action": [
-            "s3:ListBucket",
-            "s3:PutObject",
-            "s3:PutObjectTagging",
-            "s3:PutObjectAcl",
-            "s3:DeleteObject"
-        ],
-        "Resource": [
-            "arn:aws:s3:::media.avrae.io*"
-        ]
+      "Effect": "Allow",
+      "Action": [
+        "ecr:*"
+      ],
+      "Resource": [
+        "arn:aws:ecr:${var.region}:${var.account_id}:repository/avrae/taine",
+        "arn:aws:ecr:${var.region}:${var.account_id}:repository/avrae/avrae-bot",
+        "arn:aws:ecr:${var.region}:${var.account_id}:repository/avrae/avrae-service",
+        "arn:aws:ecr:${var.region}:${var.account_id}:repository/avrae/avrae-io"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ecr:GetAuthorizationToken"
+      ],
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ecs:DescribeServices",
+        "ecs:Update*"
+      ],
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket",
+        "s3:PutObject",
+        "s3:PutObjectTagging",
+        "s3:PutObjectAcl",
+        "s3:DeleteObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::media.avrae.io*",
+      ]
     }
   ]
 }
 EOF
-
 }
 
 resource "aws_iam_user_policy_attachment" "service_deploy_policy_attach" {

--- a/modules/iam-deploy/variables.tf
+++ b/modules/iam-deploy/variables.tf
@@ -14,3 +14,6 @@ variable "region" {
   description = "AWS region"
 }
 
+variable "s3_prefix" {
+  description = "shared S3 prefix for service buckets"
+}

--- a/modules/s3-avrae/main.tf
+++ b/modules/s3-avrae/main.tf
@@ -41,6 +41,17 @@ POLICY
   )
 }
 
+# lambda pre-deploy bucket
+resource "aws_s3_bucket" "lambda_archives" {
+  bucket = "${var.s3_prefix}-${var.region}-${var.service}-${var.env}-lambda-archives"
+  acl = "private"
+  tags = merge(
+  local.common_tags,
+  {
+    "Name" = "${var.service}-lambda-archives"
+  })
+}
+
 # ==== VPC ====
 # VPC: avrae route tables
 data "aws_route_tables" "avrae_route_tables" {

--- a/modules/s3-avrae/main.tf
+++ b/modules/s3-avrae/main.tf
@@ -52,6 +52,13 @@ resource "aws_s3_bucket" "lambda_archives" {
   })
 }
 
+resource "aws_s3_bucket_public_access_block" "lambda_archives" {
+  bucket                  = aws_s3_bucket.lambda_archives.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
 # ==== VPC ====
 # VPC: avrae route tables
 data "aws_route_tables" "avrae_route_tables" {


### PR DESCRIPTION
Adds an S3 bucket to hold avrae lambda code, and updates the IAM deploy user to have access to both that bucket (and any other avrae S3 buckets) and avrae lambdas.

