### PR TITLE
add gamelog rest api endpt to tf

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -440,6 +440,10 @@ module "avrae_bot_ecs" {
       name = "MONSTER_TOKEN_ENDPOINT"
       value = module.s3_avrae.token_s3_endpoint
     },
+//    {  // todo uncomment this on prod release
+//      name = "DDB_GAMELOG_ENDPOINT"
+//      value = "https://${data.aws_api_gateway_rest_api.gamelog_rest_api.id}.execute-api.${var.region}.amazonaws.com/v1"
+//    },
   ]
   secrets = [
     {
@@ -588,6 +592,10 @@ module "avrae_bot_nightly_ecs" {
     {
       name = "MONSTER_TOKEN_ENDPOINT"
       value = module.s3_avrae.token_s3_endpoint
+    },
+    {
+      name = "DDB_GAMELOG_ENDPOINT"
+      value = "https://${data.aws_api_gateway_rest_api.gamelog_rest_api.id}.execute-api.${var.region}.amazonaws.com/v1"
     },
   ]
   secrets = [
@@ -916,4 +924,8 @@ module "s3_avrae" {
   vpc_id        = module.ecs_vpc.aws_vpc_main_id
   s3_prefix     = var.s3_prefix
   subnet_ids    = module.ecs_vpc.private_subnet_ids
+}
+
+data "aws_api_gateway_rest_api" "gamelog_rest_api" {
+  name = "game-log-gamelog-rest-${var.env}"
 }


### PR DESCRIPTION
[vpc services are not allowed to use the DNS](https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-custom-domains.html), so we have to use this

pulling this in w/o review since it only affects nightly
